### PR TITLE
fix: use label on cwv target values

### DIFF
--- a/components/compounds/budget-breakdown-table/index.tsx
+++ b/components/compounds/budget-breakdown-table/index.tsx
@@ -13,7 +13,7 @@ export default function BudgetBreakdownTable() {
         <Row>
           {budgetValues.map((budgetValue) => (
             <HeadingColumn key={budgetValue.name}>
-              {budgetValue.name}
+              {budgetValue.label}
             </HeadingColumn>
           ))}
         </Row>


### PR DESCRIPTION
A small bug fix changing the label to be correct