### PR TITLE
chore: next build in github actions

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -1,0 +1,24 @@
+name: Run Next Build
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      
+      # Check out the repository
+      - uses: actions/checkout@v1
+
+      # Install Node.js
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      # Install your dependencies
+      - run: yarn
+
+      # Run Build
+      - run: yarn run build


### PR DESCRIPTION
Run the next build in GitHub Actions so there is fast feedback on typescript errors without having to jump across to Vercel